### PR TITLE
[feature/Board] 조회수 기능 & WebClient 임시구현 & 오류 fix

### DIFF
--- a/mbbk/mbbd/build.gradle
+++ b/mbbk/mbbd/build.gradle
@@ -27,8 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	//swagger2
-	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
-	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	//db, jpa
 	implementation 'mysql:mysql-connector-java'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/mbbk/mbbd/build.gradle
+++ b/mbbk/mbbd/build.gradle
@@ -32,7 +32,9 @@ dependencies {
 	//db, jpa
 	implementation 'mysql:mysql-connector-java'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
+	//WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 }
 
 allprojects{

--- a/mbbk/mbbd/src/main/java/com/mbti/board/config/swagger/SwaggerConfig.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/config/swagger/SwaggerConfig.java
@@ -2,23 +2,32 @@ package com.mbti.board.config.swagger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
 
     @Bean
     public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
+        return new Docket(DocumentationType.OAS_30)
+                .useDefaultResponseMessages(false)
                 .select()
-                .apis(RequestHandlerSelectors.any())
+                .apis(RequestHandlerSelectors.basePackage("com.mbti.board.mainBoard.controller"))
                 .paths(PathSelectors.any())
-                .build();
+                .build()
+                .apiInfo(apiInfo());
     }
 
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("mbtiBoard")
+                .description("mbti게시판 backend")
+                .version("1.0")
+                .build();
+    }
 }

--- a/mbbk/mbbd/src/main/java/com/mbti/board/externalApi/Client/UserClient.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/externalApi/Client/UserClient.java
@@ -1,0 +1,26 @@
+package com.mbti.board.externalApi.Client;
+
+import com.mbti.board.externalApi.response.UserResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+public class UserClient {
+    private static final WebClient webClient = WebClient.create( "http://localhost:8082/user/");
+
+    public boolean retrieveUserById(String id){
+        UserResponse userResponse =
+            webClient.get()
+                .uri("retrieveUserById/{id}", id)
+                .retrieve()
+                .bodyToMono(UserResponse.class)
+                .block();
+
+        if(userResponse != null)
+            return userResponse.getId().equals(id);
+        else
+            return false;
+    }
+
+
+
+}

--- a/mbbk/mbbd/src/main/java/com/mbti/board/externalApi/response/UserResponse.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/externalApi/response/UserResponse.java
@@ -1,0 +1,33 @@
+package com.mbti.board.externalApi.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+public class UserResponse {
+
+    private String email;
+    private String id;
+    private String pw;
+    private String name;
+    private String picture;
+    private String mbti;
+    private Role role;
+    private Date lastAccessDate;
+    private Date firstAccessDate;
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Role {
+        GUEST("ROLE_GUEST", "손님"),
+        USER("ROLE_USER", "일반 사용자");
+
+        private final String key;
+        private final String title;
+
+    }
+}

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/controller/PostController.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/controller/PostController.java
@@ -32,8 +32,8 @@ public class PostController {
 
     @GetMapping
     public ApiResult<List<Post.postForBoard>> readList(
-            @RequestParam @Min(value = 1, message = "첫 페이지보다 더 이전의 페이지를 조회했습니다.") int page,
-            @RequestParam @Min(value = 1, message = "한 페이지에 최소 한 개 이상의 정보가 표시되어야 합니다.") int limit
+            @RequestParam(defaultValue = "1") @Min(value = 1, message = "첫 페이지보다 더 이전의 페이지를 조회했습니다.") int page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "한 페이지에 최소 한 개 이상의 정보가 표시되어야 합니다.") int limit
     ){
         return ApiResult.success(postService.readPostList(page, limit), HttpStatus.OK);
     }

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/controller/PostController.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/controller/PostController.java
@@ -37,8 +37,8 @@ public class PostController {
 
     @GetMapping
     public ApiResult<List<Post.postForBoard>> readList(
-            @RequestParam @Min(value = 1, message = "첫 페이지보다 더 이전의 페이지를 조회했습니다.") int page,
-            @RequestParam @Min(value = 1, message = "한 페이지에 최소 한 개 이상의 정보가 표시되어야 합니다.") int limit
+            @RequestParam(defaultValue = "1") @Min(value = 1, message = "첫 페이지보다 더 이전의 페이지를 조회했습니다.") int page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "한 페이지에 최소 한 개 이상의 정보가 표시되어야 합니다.") int limit
     ){
         return ApiResult.success(postService.readPostList(page, limit), HttpStatus.OK);
     }

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/controller/PostController.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/controller/PostController.java
@@ -27,8 +27,8 @@ public class PostController {
 
     @PostMapping
     public ApiResult<String> create(
-            @RequestPart(value="image", required=false) List<MultipartFile> files,
-            @RequestPart @Valid Post post
+            @RequestPart @Valid Post post,
+            @RequestPart(value="image", required=false) List<MultipartFile> files
     ){
         postService.createPost(post);
         postFileService.insertBoardFile(post);

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/Comment.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/Comment.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -29,25 +31,12 @@ public class Comment {
     private String text;
 
     @Column(nullable = false)
+    @CreationTimestamp
     private LocalDateTime insDate;
 
     @Column(nullable = false)
+    @UpdateTimestamp
     private LocalDateTime updDate;
-
-    public void setTimeBeforeInsert(){
-        this.insDate = LocalDateTime.now();
-        this.updDate = LocalDateTime.now();
-    }
-
-    public boolean updateCommentInfo(CommentForUpdate comment) {
-        if (comment.getCommentNo() == this.getCommentNo()) {
-            this.text = comment.text;
-            this.updDate = LocalDateTime.now();
-            return true;
-        }
-        return false;
-
-    }
 
 
     @Getter

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/MBTIType.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/MBTIType.java
@@ -1,0 +1,18 @@
+package com.mbti.board.mainBoard.dto;
+
+public enum MBTIType {
+    ISTJ(1), ISTP(2), ISFJ(3), ISFP(4),
+    INTJ(5), INTP(6), INFJ(7), INFP(8),
+    ESTJ(9), ESTP(10), ESFJ(11), ESFP(12),
+    ENTJ(13), ENTP(14), ENFJ(15), ENFP(16);
+
+    private int type;
+
+    MBTIType(int type){
+        this.type = type;
+    }
+
+    public int getType(int type){
+        return type;
+    }
+}

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/Post.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/Post.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 
-//TODO: validation 에러 메시지 문구 재설정
 
 @Getter
 @Setter
@@ -35,6 +34,9 @@ public class Post {
     @NotEmpty(message = "글 본문 내용을 입력해 주세요")
     @Column(nullable = false)
     private String mainText;
+
+    @Column(nullable = false)
+    private long views;
 
     @Column(nullable = false)
     private LocalDateTime insDate;

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/Post.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/dto/Post.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.Min;
@@ -39,9 +41,11 @@ public class Post {
     private long views;
 
     @Column(nullable = false)
+    @CreationTimestamp
     private LocalDateTime insDate;
 
     @Column(nullable = false)
+    @UpdateTimestamp
     private LocalDateTime updDate;
 
     //@Transient
@@ -80,11 +84,6 @@ public class Post {
         private final LocalDateTime insDate;
     }
 
-    public void setTimeBeforeInsert(){
-        this.insDate = LocalDateTime.now();
-        this.updDate = LocalDateTime.now();
-    }
-
     // 함수명 이게 맞나..?
     public postForBoard of(){
         return postForBoard.builder().
@@ -93,15 +92,5 @@ public class Post {
             title(this.title).
             insDate(this.insDate).
             build();
-    }
-
-    public boolean updatePostInfo(PostForUpdate post){
-        if(this.author.equals(post.getAuthor()) && this.postNo == post.getPostNo()){
-            this.title = post.getTitle();
-            this.mainText = post.getMainText();
-            this.updDate = LocalDateTime.now();
-            return true;
-        }
-        return false;
     }
 }

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/repository/PostRepository.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/repository/PostRepository.java
@@ -2,8 +2,14 @@ package com.mbti.board.mainBoard.repository;
 
 import com.mbti.board.mainBoard.dto.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("update Post p set p.views = p.views + 1 where p.postNo = :postNo")
+    @Modifying
+    void increaseViews(long postNo);
 }

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/CommentService.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/CommentService.java
@@ -17,7 +17,6 @@ public class CommentService {
     @Transactional(rollbackFor = BusinessException.class)
     public void createComment(Comment comment){
         try {
-            comment.setTimeBeforeInsert();
             commentRepository.save(comment);
         } catch(BusinessException e){
             throw new BusinessException("댓글 저장 중 오류가 발생했습니다.", e);
@@ -29,7 +28,7 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentForUpdate.getCommentNo())
                 .orElseThrow(() -> new BusinessException("기존 댓글 정보가 존재하지 않습니다."));
 
-        if(comment.updateCommentInfo(commentForUpdate)){
+        if(comment.getCommentNo() == commentForUpdate.getCommentNo()){
             try {
                 commentRepository.save(comment);
             } catch(BusinessException e){

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/PostService.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/PostService.java
@@ -27,7 +27,6 @@ public class PostService {
     @Transactional(rollbackFor = BusinessException.class)
     public void createPost(Post post){
         try {
-            post.setTimeBeforeInsert();
             postRepository.save(post);
         } catch(BusinessException e){
             throw new BusinessException("글 저장 중 오류가 발생했습니다.", e);
@@ -59,7 +58,7 @@ public class PostService {
         Post post = postRepository.findById(postForUpdate.getPostNo())
                 .orElseThrow(() -> new BusinessException("기존 글 정보가 존재하지 않습니다."));
 
-        if(post.updatePostInfo(postForUpdate)){
+        if(post.getAuthor().equals(postForUpdate.getAuthor())){
             try {
                 postRepository.save(post);
             } catch(BusinessException e){

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/PostService.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/PostService.java
@@ -38,14 +38,15 @@ public class PostService {
             List<Post> postList = postRepository.findAll(PageRequest.of(page - 1, limit, Sort.by("insDate").descending())).toList();
             return postList.stream().map(Post::of).collect(Collectors.toList());
         } catch(BusinessException e){
-            throw new BusinessException("글 저장 중 오류가 발생했습니다.", e);
+            throw new BusinessException("글 리스트 조회 중 오류가 발생했습니다.", e);
         }
     }
 
-    @Transactional(readOnly = true)
-    public Post readPostDetail(long pageNo){
-        Post post = postRepository.findById(pageNo)
+    @Transactional(rollbackFor = BusinessException.class)
+    public Post readPostDetail(long postNo){
+        Post post = postRepository.findById(postNo)
             .orElseThrow(() -> new BusinessException("글 정보가 존재하지 않습니다."));
+        postRepository.increaseViews(postNo);
         post.setComments(commentRepository.findAllByPost(post));
         return post;
     }

--- a/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/PostService.java
+++ b/mbbk/mbbd/src/main/java/com/mbti/board/mainBoard/service/PostService.java
@@ -40,14 +40,15 @@ public class PostService {
             List<Post> postList = postRepository.findAll(PageRequest.of(page - 1, limit, Sort.by("insDate").descending())).toList();
             return postList.stream().map(Post::of).collect(Collectors.toList());
         } catch(BusinessException e){
-            throw new BusinessException("글 저장 중 오류가 발생했습니다.", e);
+            throw new BusinessException("글 리스트 조회 중 오류가 발생했습니다.", e);
         }
     }
 
-    @Transactional(readOnly = true)
-    public Post readPostDetail(long pageNo){
-        Post post = postRepository.findById(pageNo)
+    @Transactional(rollbackFor = BusinessException.class)
+    public Post readPostDetail(long postNo){
+        Post post = postRepository.findById(postNo)
             .orElseThrow(() -> new BusinessException("글 정보가 존재하지 않습니다."));
+        postRepository.increaseViews(postNo);
         post.setComments(commentRepository.findAllByPost(post));
         post.setPostFiles(postFileRepository.findAllByPost(post));
         return post;

--- a/mbbk/mbbd/src/main/resources/application.yml
+++ b/mbbk/mbbd/src/main/resources/application.yml
@@ -19,11 +19,11 @@ spring:
     username: ssafy
     password: ssafy
 
-    jpa:
-      database: mysql
-      show-sql: true
-      hibernate:
-        ddl-auto: update
+  jpa:
+    database: mysql
+    show-sql: true
+    hibernate:
+      ddl-auto: update
 
 logging:
   pattern:

--- a/mbbk/mbbd/src/main/resources/application.yml
+++ b/mbbk/mbbd/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+server:
+  port: 8081
+  servlet:
+    context-path: /v1
+    encoding:
+      charset: UTF-8
+  error:
+    whitelabel:
+      enabled: false
+
+spring:
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/mbur?serverTimezone=UTC&characterEncoding=UTF-8
+    username: root
+    password: 1111
+
+    jpa:
+      database: mysql
+      show-sql: true
+      hibernate:
+        ddl-auto: update
+
+logging:
+  pattern:
+    console: "[ %d{ HH:mm:ss.SSS } ][ %-5level ][ %logger.%method:line%line ] - %msg%n"

--- a/mbbk/mbbd/src/main/resources/application.yml
+++ b/mbbk/mbbd/src/main/resources/application.yml
@@ -15,9 +15,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/mbur?serverTimezone=UTC&characterEncoding=UTF-8
-    username: root
-    password: 1111
+    url: jdbc:mysql://localhost:3306/toyproject_db?serverTimezone=UTC&characterEncoding=UTF-8
+    username: ssafy
+    password: ssafy
 
     jpa:
       database: mysql


### PR DESCRIPTION
## DONE
1. 조회수 기능 추가(단순 조회 이벤트 발생 시 조회수 + 1)
2. WebClient 임시구현 (Spring MVC, Spring WebFlux 차이를 아직 잘 이해를 못했습니다..)
3. 간단한 이슈들 처리
   3-1. 삭제된 application.yml 복구 및 문법오류 fix
   3-2. 파일 업로드 기능으로 RequestPart 사용 -> swagger2에선 미지원 -> swagger3으로 버전업
   3-3. db 삽입 & 수정 날짜 어노테이션을 통한 처리로 변경
   3-4. MBTI 타입 enum문 추가
   3-5. 페이지 리스트 조회 api default값 추가
## TODO
1. WebClient 관련 학습 및 mbur 참조해서 제대로 구현해두기
2. 새로 구현할 기능 찾아서 시작하기

28일까지 끝내야 하는 플젝이 하나 있었어서 작업량이 많이 적습니다...ㅠㅠ
이번주는 QA 진행하는 것 말고는 크게 이슈 없을거라 토이플젝 많이 진행할게요!